### PR TITLE
Bug fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+output

--- a/README.md
+++ b/README.md
@@ -13,16 +13,17 @@ using session token and the second part of `#EXT-X-MEDIA-READY`.
 
 ## Usage
 
-Spicify `--url` and `--pin` in command line arguments:
+Spicify `--entity` and `--pin` in command line arguments:
 
 ```bash
-https://play.boomstream.com/TiAR7aDs?ppv=EswAWlFa --pin 123-456-789
+--entity TiAR7aDs --pin 123-456-789
 ```
+`entity` value can be found in URL like https://play.boomstream.com/TiAR7aDs
 
 You can also specify a resolution using `--resolution` command line argument:
 
 ```bash
-https://play.boomstream.com/TiAR7aDs?ppv=EswAWlFa --pin 123-456-789 --resolution "640x360"
+--entity TiAR7aDs --pin 123-456-789 --resolution "640x360"
 ```
 
 If resolution is not specified, the video with a highest one will be dowloaded.

--- a/README.md
+++ b/README.md
@@ -13,20 +13,18 @@ using session token and the second part of `#EXT-X-MEDIA-READY`.
 
 ## Usage
 
-Spicify `--entity` and `--pin` in command line arguments:
+Command line arguments:
 
-```bash
---entity TiAR7aDs --pin 123-456-789
-```
-`entity` value can be found in URL like https://play.boomstream.com/TiAR7aDs
+`--entity` (required) - value can be found in URL like https://play.boomstream.com/TiAR7aDs
 
-You can also specify a resolution using `--resolution` command line argument:
+`--pin` - required only for content protected with a pin code
 
+`--resolution` - video resolution. If not specified, the video with a highest one will be downloaded
+
+Excample:
 ```bash
 --entity TiAR7aDs --pin 123-456-789 --resolution "640x360"
 ```
-
-If resolution is not specified, the video with a highest one will be dowloaded.
 
 ## Requirements
 

--- a/boomstream.py
+++ b/boomstream.py
@@ -248,7 +248,9 @@ class App(object):
         print("Merging chunks...")
         run_bash(f"cat {' '.join(filenames)} > {output_path(key)}.ts")
         print("Encoding to MP4")
-        run_bash(f'ffmpeg -i {output_path(key)}.ts -c copy "{output_path(valid_filename(self.get_title()))}".mp4')
+        ensure_folder_exists(output_path("results"))
+        result_filename = output_path(os.path.join("results", f"{valid_filename(self.get_title())}.mp4"))
+        run_bash(f'ffmpeg -i {output_path(key)}.ts -c copy "{result_filename}"')
 
     def get_title(self):
         return self.config['entity']['title']

--- a/boomstream.py
+++ b/boomstream.py
@@ -249,7 +249,7 @@ class App(object):
         result_duration = float([line[len("duration="):] for line in result_format.split('\n') if line.startswith("duration=")][0])
         print(f"Result duration: {result_duration:.2f}")
         print(f"Expected duration: {expected_result_duration:.2f}")
-        if abs(result_duration - expected_result_duration) > 1:
+        if abs(result_duration - expected_result_duration) > 2:
             raise ValueError(f"unexpected result duration: {expected_result_duration:.2f} != {result_duration:.2f}")
 
         ensure_folder_exists(output_path("results"))

--- a/boomstream.py
+++ b/boomstream.py
@@ -73,7 +73,8 @@ class App(object):
 
     def get_playlist(self, url):
         if self.args.use_cache and os.path.exists('boomstream.playlist.m3u8'):
-            return open('boomstream.playlist.m3u8').read()
+            with open('boomstream.playlist.m3u8') as f:
+                return f.read()
 
         r = requests.get(url, headers=headers)
 
@@ -132,7 +133,8 @@ class App(object):
             raise Exception("Could not find chunklist in playlist data")
 
         if self.args.use_cache and os.path.exists('boomstream.chunklist.m3u8'):
-            return open('boomstream.chunklist.m3u8').read()
+            with open('boomstream.chunklist.m3u8') as f:
+                return f.read()
 
         r = requests.get(url, headers=headers)
 

--- a/boomstream.py
+++ b/boomstream.py
@@ -229,7 +229,7 @@ class App(object):
             if not line.startswith('https://'):
                 continue
             outf = output_path(os.path.join(key, f"{i:05d}.ts"))
-            if os.path.exists(outf):
+            if os.path.exists(outf) and os.path.getsize(outf) > 0:
                 i += 1
                 print(f"Chunk #{i} exists [{outf}]")
                 continue

--- a/boomstream.py
+++ b/boomstream.py
@@ -59,16 +59,10 @@ class App(object):
         self.args = parser.parse_args()
 
     def get_token(self):
-        if 'records' in self.config['mediaData'] and len(self.config['mediaData']['records']) > 0:
-            return b64decode(self.config['mediaData']['records'][0]['token']).decode('utf-8')
-        else:
-            return b64decode(self.config['mediaData']['token']).decode('utf-8')
+        return b64decode(self.config['mediaData']['token']).decode('utf-8')
 
     def get_m3u8_url(self):
-        if 'records' in self.config['mediaData'] and len(self.config['mediaData']['records']) > 0:
-            return b64decode(self.config['mediaData']['records'][0]['links']['hls']).decode('utf-8')
-        else:
-            return b64decode(self.config['mediaData']['links']['hls']).decode('utf-8')
+        return b64decode(self.config['mediaData']['links']['hls']).decode('utf-8')
 
     def get_boomstream_config(self, page):
         """

--- a/boomstream.py
+++ b/boomstream.py
@@ -263,7 +263,13 @@ class App(object):
         r = requests.post("https://play.boomstream.com/api/subscriptions/recovery",
                           headers={'content-type': 'application/json;charset=UTF-8'},
                           data=f'{{"entity":"{self.args.entity}","code":"{self.args.pin}"}}')
-        cookie = json.loads(r.text)["data"]["cookie"]
+        response = json.loads(r.text)
+        if "data" not in response or "cookie" not in response["data"]:
+            if "errors" not in response or "code" not in response:
+                raise ValueError(f"unexpected response on authorization: {r.text}")
+            else:
+                raise ValueError(f"authorization failed: {response['code']} {response['errors']}")
+        cookie = response["data"]["cookie"]
         return {cookie["name"]: cookie["value"]}
 
     def run(self):


### PR DESCRIPTION
## Changes

- code style fixes
- fix bug: close opened files
- use a separate directory for output files
- support videos protected with a pin code
- use entity id instead of url
- exit on keyboard interrupt while running bash scripts
- fix bug: re-download empty cached parts
- overwrite a converted file if exists
- check result video duration
- fix bug: remove usages of `config['mediaData']['records']`. **I did not get where it comes from, I do not have it in my video configs, please, let me know if this is a special video type that I'm not aware of. I guess it is just an outdated format.**
